### PR TITLE
fix a bug in linux new kernel when scan device

### DIFF
--- a/smartie/device.py
+++ b/smartie/device.py
@@ -6,6 +6,7 @@ import abc
 import itertools
 import ctypes
 import platform
+import os
 from pathlib import Path
 from typing import Iterable, List, Optional, Union
 
@@ -114,7 +115,12 @@ def get_all_devices() -> Iterable[Device]:
             if not child.name.startswith(("sd", "nvme")):
                 continue
 
-            yield get_device(Path("/dev") / child.name)
+            # In the new kernel, nvme device may has a character device like 
+            # nvme0c0n1 (/sys/block/nvme0c0n1), but it is not in the directo
+            # -ry /dev/.
+            device_path = Path("/dev") / child.name
+            if os.path.exists(device_path):
+                yield get_device(device_path)
     elif system == "Windows":
         k32 = ctypes.WinDLL("kernel32", use_last_error=True)
 


### PR DESCRIPTION
fix a bug in linux new kernel when scan nvme device. Here is what I found:

```
[gaozh3@fedora smartie]$ nvme list
Node                  Generic               SN                   Model                                    Namespace  Usage                      Format           FW Rev
--------------------- --------------------- -------------------- ---------------------------------------- ---------- -------------------------- ---------------- --------
/dev/nvme0n1          /dev/ng0n1            S5LFNE0MC00032       MZPLJ1T6HBJR-000V5                       0x1          3.20  TB /   3.20  TB    512   B +  0 B   CQ37
[gaozh3@fedora smartie]$ ls /sys/block/
nvme0c0n1  nvme0n1  sda  zram0
[gaozh3@fedora smartie]$ ls /dev/nvme*
/dev/nvme0  /dev/nvme0n1
[gaozh3@fedora smartie]$
```