### PR TITLE
Windows SPTI timeout value is in seconds, not milliseconds.

### DIFF
--- a/smartie/scsi/windows.py
+++ b/smartie/scsi/windows.py
@@ -46,7 +46,7 @@ class WindowsSCSIDevice(SCSIDevice):
         command: ctypes.Structure,
         data: Union[ctypes.Array, ctypes.Structure],
         *,
-        timeout: int = 3000,
+        timeout: int = 3,
     ):
         # On Windows, the command block is always 16 bytes, but we may be
         # sending a smaller command. We use a temporary mutable bytearray for


### PR DESCRIPTION
Windows SPTI timeout value is in seconds, not milliseconds.. So changed 3000 to 3.

from: https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/ntddscsi/ns-ntddscsi-_scsi_pass_through_direct

"""
TimeOutValue
Indicates the interval in seconds that the request can execute before the OS-specific port driver might consider it timed out.
"""