### PR TITLE
Added support for scsi commands with no data.

### DIFF
--- a/smartie/scsi/linux.py
+++ b/smartie/scsi/linux.py
@@ -45,6 +45,9 @@ class LinuxSCSIDevice(SCSIDevice):
             ),
         )
 
+        if data is None:
+            data = ctypes.create_string_buffer(0)
+
         sg_io_header = SGIOHeader(
             interface_id=83,  # Always 'S'
             dxfer_direction=direction,

--- a/smartie/scsi/structures.py
+++ b/smartie/scsi/structures.py
@@ -121,6 +121,7 @@ class Direction(enum.IntEnum):
         map them for other platforms.
     """
 
+    NONE = -1
     TO = -2
     FROM = -3
 

--- a/smartie/scsi/windows.py
+++ b/smartie/scsi/windows.py
@@ -55,10 +55,13 @@ class WindowsSCSIDevice(SCSIDevice):
             bytearray(command).ljust(16, b"\x00")  # noqa
         )
 
+        if data is None:
+            data = ctypes.create_string_buffer(0)
+
         header_with_buffer = SCSIPassThroughDirectWithBuffer(
             sptd=SCSIPassThroughDirect(
                 length=ctypes.sizeof(SCSIPassThroughDirect),
-                data_in={Direction.TO: 0, Direction.FROM: 1}.get(direction),
+                data_in={Direction.TO: 0, Direction.FROM: 1, Direction.NONE: 2}.get(direction),
                 data_transfer_length=ctypes.sizeof(data),
                 data_buffer=ctypes.addressof(data),
                 cdb_length=ctypes.sizeof(command),


### PR DESCRIPTION
Currently there is only support for scsi commands that either send or receive data, but some commands do not send or receive any data. I added support for these "no data" commands. A common example is the "Test Unit Ready" scsi comand, which is 6 bytes of all 00. The result of this command is gotten from the sense data bytes.

https://docs.oracle.com/en/storage/tape-storage/sl4000/slksr/test-unit-ready-00h.html

I succesfully tested the windows version of these changes but did not test the linux version.

Since no data is sent I would expect to pass "None" for the "data" parameter in the SCSIDevice::issue_command() methods. So I added checks for None and create an empty data buffer inside the method. I wasn't sure if I should add "None" in the parameter specification here: "data: Union[ctypes.Array, ctypes.Structure],"