### PR TITLE
Use BigEndianStructure for Command16.

### DIFF
--- a/smartie/scsi/__init__.py
+++ b/smartie/scsi/__init__.py
@@ -235,9 +235,7 @@ class SCSIDevice(Device, abc.ABC):
                 t_dir=True,
                 ck_cond=True,
             ),
-            features=smartie.structures.swap_int(
-                2, ATASmartFeature.SMART_READ_THRESHOLDS
-            ),
+            features=ATASmartFeature.SMART_READ_THRESHOLDS,
         ).set_lba(0xC24F00)
 
         response = self.issue_command(Direction.FROM, command16, thresholds)
@@ -259,9 +257,7 @@ class SCSIDevice(Device, abc.ABC):
                 t_dir=True,
                 ck_cond=True,
             ),
-            features=smartie.structures.swap_int(
-                2, ATASmartFeature.SMART_READ_DATA
-            ),
+            features=ATASmartFeature.SMART_READ_DATA,
         ).set_lba(0xC24F00)
 
         response = self.issue_command(Direction.FROM, command16, smart)

--- a/smartie/scsi/structures.py
+++ b/smartie/scsi/structures.py
@@ -291,7 +291,7 @@ class Command12(ctypes.Structure):
     ]
 
 
-class Command16(ctypes.Structure):
+class Command16(ctypes.BigEndianStructure):
     """
     A 16-byte SCSI/ATA passthrough command.
 

--- a/smartie/structures.py
+++ b/smartie/structures.py
@@ -40,12 +40,6 @@ def swap_bytes(src):
     return src
 
 
-def swap_int(c: int, n: int) -> int:
-    return int.from_bytes(
-        n.to_bytes(c, byteorder="little"), byteorder="big", signed=False
-    )
-
-
 def embed_bytes(data: bytes, *, indent=0, char="    ", max_width=80) -> str:
     """
     Pretty-prints `data` in such a way that it can be embedded cleanly in


### PR DESCRIPTION
This avoids explicitly byteswap and fixes errors on big endian systems (if any).